### PR TITLE
Fix variable assignments for use with react-native-web

### DIFF
--- a/lib/useDeviceOrientation.js
+++ b/lib/useDeviceOrientation.js
@@ -1,34 +1,31 @@
-import React, { useEffect, useState } from 'react';
-import { Dimensions } from 'react-native';
+import React, { useEffect, useState } from 'react'
+import { Dimensions } from 'react-native'
 
-const screen = Dimensions.get('screen');
+const screen = Dimensions.get('screen')
+
+const isOrientationPortrait = ({ width, height }) => height >= width
+const isOrientationLandscape = ({ width, height }) => width >= height
 
 export default function() {
-  isOrientationPortrait = ({ width, height }) => height >= width;
-  isOrientationLandscape = ({ width, height }) => width >= height;
-
   const [orientation, setOrientation] = useState({
     portrait: isOrientationPortrait(screen),
-    landscape: isOrientationLandscape(screen)
-  });
+    landscape: isOrientationLandscape(screen),
+  })
 
-  onChange = ({ screen }) => {
+  const onChange = ({ screen }) => {
     setOrientation({
       portrait: isOrientationPortrait(screen),
-      landscape: isOrientationLandscape(screen)
-    });
-  };
+      landscape: isOrientationLandscape(screen),
+    })
+  }
 
-  useEffect(
-    () => {
-      Dimensions.addEventListener('change', onChange);
+  useEffect(() => {
+    Dimensions.addEventListener('change', onChange)
 
-      return () => {
-        Dimensions.removeEventListener('change', onChange);
-      };
-    },
-    [orientation.portrait, orientation.landscape]
-  );
+    return () => {
+      Dimensions.removeEventListener('change', onChange)
+    }
+  }, [])
 
-  return orientation;
+  return orientation
 };

--- a/lib/useDimensions.js
+++ b/lib/useDimensions.js
@@ -9,7 +9,7 @@ export default function useDimensions() {
     window, screen
   })
 
-  onChange = ({ window, screen }) => {
+  const onChange = ({ window, screen }) => {
     setDimensions({ window, screen })
   }
 

--- a/lib/useKeyboard.js
+++ b/lib/useKeyboard.js
@@ -23,28 +23,30 @@ export default function useKeyboard() {
   }
 
   useEffect(() => {
-    keyboardDidShowListener = Keyboard.addListener(
+    const keyboardWillShowListener = Keyboard.addListener(
       'keyboardWillShow',
       keyboardHidden
     )
 
-    keyboardDidShowListener = Keyboard.addListener(
+    const keyboardDidShowListener = Keyboard.addListener(
       'keyboardDidShow',
       keyboardShown
     )
 
-    keyboardDidShowListener = Keyboard.addListener(
+    const keyboardWillHideListener = Keyboard.addListener(
       'keyboardWillHide',
       keyboardShown
     )
 
-    keyboardDidHideListener = Keyboard.addListener(
+    const keyboardDidHideListener = Keyboard.addListener(
       'keyboardDidHide',
       keyboardHidden
     )
 
     return () => {
+      keyboardWillShowListener.remove()
       keyboardDidShowListener.remove()
+      keyboardWillHideListener.remove()
       keyboardDidHideListener.remove()
     }
   }, [])


### PR DESCRIPTION
# Summary

In some hooks variables were assigned without the `const`/`let` keyword. I'm not sure why this works in a native build, but when used in a browser with `react-native-web` it does not. The keywords have been added.

Also fixed:

- `useKeyboard` event handler names and removing all four listeners.
- `useDeviceOrientation` `useEffect` only needs to be run on mount, so empty dependencies array.

## Test Plan

### What's required for testing (prerequisites)?

Set up a project for the browser using `react-native-web`.

### What are the steps to reproduce (after prerequisites)?

Observe the hooks work fine with the `const` keywords added.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
