### PR TITLE
Use a global list of clipboard listeners

### DIFF
--- a/src/useClipboard.ts
+++ b/src/useClipboard.ts
@@ -1,22 +1,30 @@
 import {useEffect, useState} from 'react'
 import {Clipboard} from 'react-native'
 
+type Listener = (content: string) => void
+const listeners = new Set<Listener>()
+
+function setString(content: string) {
+  Clipboard.setString(content)
+  listeners.forEach(listener => listener(content))
+}
+
 export default function useClipBoard() {
   const [data, updateClipboardData] = useState('')
 
-  async function updateClipboard() {
-    const content = await Clipboard.getString()
-    updateClipboardData(content)
-  }
-
+  // Get initial data
   useEffect(() => {
-    updateClipboard()
+    Clipboard.getString().then(updateClipboardData)
   }, [])
 
-  function setString(content: string) {
-    Clipboard.setString(content)
-    updateClipboardData(content)
-  }
+  // Listen for updates
+  useEffect(() => {
+    listeners.add(updateClipboardData)
+
+    return () => {
+      listeners.delete(updateClipboardData)
+    }
+  }, [])
 
   return [data, setString]
 }


### PR DESCRIPTION
# Summary

Before this change, if two components on the same page used the clipboard hook, one of them wouldn't properly re-render if the other one updated the clipboard content.

## Test Plan

~~I'm working on a small example app that shows two components that uses the clipboard at the same time, and demonstrates that it now works.~~

Here is a snack that demonstrates the working behaviour:
https://snack.expo.io/@linusu/hooks-pr-76

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [n/a] I added the documentation in `README.md`
- [n/a] I mentioned this change in `CHANGELOG.md`
- [n/a] I updated the typed files (TS and Flow)
- [n/a] I added a sample use of the API in the example project (`example/App.js`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.4.4-canary.76.172.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @react-native-community/hooks@2.4.4-canary.76.172.0
  # or 
  yarn add @react-native-community/hooks@2.4.4-canary.76.172.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
