### PR TITLE
chore: specify type for clipboard

### DIFF
--- a/src/useClipboard.ts
+++ b/src/useClipboard.ts
@@ -9,7 +9,7 @@ function setString(content: string) {
   listeners.forEach(listener => listener(content))
 }
 
-export default function useClipBoard() {
+export default function useClipBoard(): [string, (content: string) => void] {
   const [data, updateClipboardData] = useState('')
 
   // Get initial data


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Made the return type of `useClipBoard` more specific.

Originally, the inferred return type was `(string | typeof setString)[];` which makes it very difficult to use in typescript, because it is unsure weather first element of the array is string or `setString`. 

By explicitly setting the return type, typescript will know that first item in the array is a string, and second item in the array is a function.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
| Web     |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I updated the typed files (TS and Flow)

