### PR TITLE
[META] Stop using default export internally

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
-import useDimensions from './useDimensions'
-import useAppState from './useAppState'
-import useBackHandler from './useBackHandler'
-import useCameraRoll from './useCameraRoll'
-import useClipboard from './useClipboard'
-import useAccessibilityInfo from './useAccessibilityInfo'
-import useKeyboard from './useKeyboard'
-import useInteractionManager from './useInteractionManager'
-import useDeviceOrientation from './useDeviceOrientation'
-import useLayout from './useLayout'
+import {useDimensions} from './useDimensions'
+import {useAppState} from './useAppState'
+import {useBackHandler} from './useBackHandler'
+import {useCameraRoll} from './useCameraRoll'
+import {useClipboard} from './useClipboard'
+import {useAccessibilityInfo} from './useAccessibilityInfo'
+import {useKeyboard} from './useKeyboard'
+import {useInteractionManager} from './useInteractionManager'
+import {useDeviceOrientation} from './useDeviceOrientation'
+import {useLayout} from './useLayout'
 
 export {
   useDimensions,

--- a/src/useAccessibilityInfo.ts
+++ b/src/useAccessibilityInfo.ts
@@ -5,7 +5,7 @@ import {
   AccessibilityEvent,
 } from 'react-native'
 
-export default function useAccessibilityInfo() {
+export function useAccessibilityInfo() {
   const [reduceMotionEnabled, setReduceMotionEnabled] = useState(false)
   const [screenReaderEnabled, setScreenReaderEnabled] = useState(false)
 

--- a/src/useAppState.ts
+++ b/src/useAppState.ts
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react'
 import {AppState, AppStateStatus} from 'react-native'
 
-export default function useAppState() {
+export function useAppState() {
   const currentState = AppState.currentState
   const [appState, setAppState] = useState(currentState)
 

--- a/src/useBackHandler.ts
+++ b/src/useBackHandler.ts
@@ -1,7 +1,7 @@
 import {useEffect} from 'react'
 import {BackHandler} from 'react-native'
 
-export default function useBackHandler(handler: () => boolean) {
+export function useBackHandler(handler: () => boolean) {
   useEffect(() => {
     BackHandler.addEventListener('hardwareBackPress', handler)
 

--- a/src/useCameraRoll.ts
+++ b/src/useCameraRoll.ts
@@ -15,7 +15,7 @@ const defaultConfig: GetPhotosParamType = {
   groupTypes: 'All',
 }
 
-export default function useCameraRoll() {
+export function useCameraRoll() {
   const [photos, setPhotos] = useState(initialState)
 
   async function getPhotos(config = defaultConfig) {

--- a/src/useClipboard.ts
+++ b/src/useClipboard.ts
@@ -9,7 +9,7 @@ function setString(content: string) {
   listeners.forEach(listener => listener(content))
 }
 
-export default function useClipBoard(): [string, (content: string) => void] {
+export function useClipboard(): [string, (content: string) => void] {
   const [data, updateClipboardData] = useState('')
 
   // Get initial data

--- a/src/useDeviceOrientation.ts
+++ b/src/useDeviceOrientation.ts
@@ -3,7 +3,7 @@ import {Dimensions, ScaledSize} from 'react-native'
 
 const screen = Dimensions.get('screen')
 
-export default function() {
+export function useDeviceOrientation() {
   const isOrientationPortrait = ({
     width,
     height,

--- a/src/useDimensions.ts
+++ b/src/useDimensions.ts
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react'
 import {Dimensions, ScaledSize} from 'react-native'
 
-export default function useDimensions() {
+export function useDimensions() {
   const [dimensions, setDimensions] = useState({
     window: Dimensions.get('window'),
     screen: Dimensions.get('screen'),

--- a/src/useInteractionManager.ts
+++ b/src/useInteractionManager.ts
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react'
 import {InteractionManager} from 'react-native'
 
-export default function useInteractionManager() {
+export function useInteractionManager() {
   const [complete, updateInteractionStatus] = useState(false)
 
   useEffect(() => {

--- a/src/useKeyboard.ts
+++ b/src/useKeyboard.ts
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react'
 import {Keyboard, KeyboardEventListener, ScreenRect} from 'react-native'
 
-export default function useKeyboard() {
+export function useKeyboard() {
   const [shown, setShown] = useState(false)
   const [coordinates, setCoordinates] = useState<{
     start: ScreenRect

--- a/src/useLayout.test.ts
+++ b/src/useLayout.test.ts
@@ -1,6 +1,6 @@
 import {renderHook} from '@testing-library/react-hooks'
 
-import useLayout from './useLayout'
+import {useLayout} from './useLayout'
 
 describe('bla', () => {
   it('should increment counter', () => {

--- a/src/useLayout.ts
+++ b/src/useLayout.ts
@@ -1,6 +1,6 @@
 import {useState, useCallback} from 'react'
 
-export default function useLayout() {
+export function useLayout() {
   const [layout, setLayout] = useState({
     x: 0,
     y: 0,


### PR DESCRIPTION
# Summary

While default exports are fine, in TS they tend to not offer too much. Autocomplete and auto-import work better without default exports, so it seems easier to just avoid them altogether.
