### PR TITLE
fix crash in android when hide keyboard

### DIFF
--- a/src/useKeyboard.ts
+++ b/src/useKeyboard.ts
@@ -25,7 +25,9 @@ export default function useKeyboard() {
   }
   const handleKeyboardDidHide: KeyboardEventListener = e => {
     setShown(false)
-    setCoordinates({start: e.startCoordinates, end: e.endCoordinates})
+    if(e){
+      setCoordinates({start: e.startCoordinates, end: e.endCoordinates});
+     }
     setKeyboardHeight(0)
   }
 

--- a/src/useKeyboard.ts
+++ b/src/useKeyboard.ts
@@ -25,9 +25,9 @@ export default function useKeyboard() {
   }
   const handleKeyboardDidHide: KeyboardEventListener = e => {
     setShown(false)
-    if(e){
-      setCoordinates({start: e.startCoordinates, end: e.endCoordinates});
-     }
+    if (e) {
+      setCoordinates({start: e.startCoordinates, end: e.endCoordinates})
+    }
     setKeyboardHeight(0)
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
this fixes issue crash in android when hiding keyboard by checking `e` variable not null 

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
*  issue crash in android when hiding keyboard 
* How did you implement the solution?
    by checking `e` variable not null 
* What areas of the library does it impact?
  android only
-->

## Test Plan
  * show keyboard and hide will crash in android in old code
  * in new code fix crash in anroid


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
android keyboard

### What are the steps to reproduce (after prerequisites)?
when use (useKeyboard) hook in android and show keyboard and hide it will crash
because of variable `e` in function handleKeyboardDidHide was null in android 
I fix it checking for variable `e` is true   

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅   |
| Web     |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ * ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
