### PR TITLE
Adding keyboardHiding and keyboardShowing state flags to useKeyboard

### DIFF
--- a/src/useKeyboard.ts
+++ b/src/useKeyboard.ts
@@ -14,6 +14,8 @@ const initialValue = {
 
 export function useKeyboard() {
   const [shown, setShown] = useState(false)
+  const [showing, setShowing] = useState(false)
+  const [hiding, setHiding] = useState(false)
   const [coordinates, setCoordinates] = useState<{
     start: ScreenRect
     end: ScreenRect
@@ -21,18 +23,22 @@ export function useKeyboard() {
   const [keyboardHeight, setKeyboardHeight] = useState<number>(0)
 
   const handleKeyboardWillShow: KeyboardEventListener = (e) => {
+    setShowing(true)
     setCoordinates({start: e.startCoordinates, end: e.endCoordinates})
   }
   const handleKeyboardDidShow: KeyboardEventListener = (e) => {
     setShown(true)
+    setShowing(false)
     setCoordinates({start: e.startCoordinates, end: e.endCoordinates})
     setKeyboardHeight(e.endCoordinates.height)
   }
   const handleKeyboardWillHide: KeyboardEventListener = (e) => {
+    setHiding(true)
     setCoordinates({start: e.startCoordinates, end: e.endCoordinates})
   }
   const handleKeyboardDidHide: KeyboardEventListener = (e) => {
     setShown(false)
+    setHiding(false)
     if (e) {
       setCoordinates({start: e.startCoordinates, end: e.endCoordinates})
     } else {
@@ -57,6 +63,8 @@ export function useKeyboard() {
 
   return {
     keyboardShown: shown,
+    keyboardShowing: showing,
+    keyboardHiding: hiding,
     coordinates,
     keyboardHeight,
   }


### PR DESCRIPTION
# Summary

This feature exposes transitional flags, `keyboardHiding` and `keyboardShowing` for when the keyboard is in the process of animating in and out. 

This is handy for preparing changes in layout that we wish to be true at the end without observing the late jank when the keyboard "lands" (e.g. by waiting for `keyboardShown` to be true.

Use Case: In iPhone X/11/S configurations, it can be handy to have a different treatment of SafeAreaContext insets when keyboard is up vs down. e.g. the sample/test below


## Test Plan

This is a really simple change. It allows the following style configuration to work nicely: 

const { keyboardHiding, keyboardShowing, keyboardShown} = useKeyboard()
```jsx
{
  marginBottom: !keyboardHiding || (keyboardShowing || keyboardShown) ? insets.bottom : 0
}
```

### What's required for testing (prerequisites)?

Nothing, this is a really simple change.

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ❌     | (don't think it applies at all)

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
