### PR TITLE
useAccessibilityInfo update

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,14 @@ yarn add @react-native-community/hooks
 ```js
 import { useAccessibilityInfo } from '@react-native-community/hooks'
 
-const { reduceMotionEnabled, screenReaderEnabled } = useAccessibilityInfo()
+const {
+  reduceMotionEnabled,
+  screenReaderEnabled,
+  grayscaleEnabled,
+  invertColorsEnabled,
+  reduceTransparencyEnabled,
+  boldTextEnabled 
+} = useAccessibilityInfo()
 ```
 
 ### `useAppState`

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ yarn add @react-native-community/hooks
 import { useAccessibilityInfo } from '@react-native-community/hooks'
 
 const {
-  reduceMotionEnabled,
+  boldTextEnabled,
   screenReaderEnabled,
-  grayscaleEnabled,
-  invertColorsEnabled,
-  reduceTransparencyEnabled,
-  boldTextEnabled 
+  reduceMotionEnabled, // requires RN60 or newer
+  grayscaleEnabled, // requires RN60 or newer
+  invertColorsEnabled, // requires RN60 or newer
+  reduceTransparencyEnabled // requires RN60 or newer
 } = useAccessibilityInfo()
 ```
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "release-canary": "auto canary"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-native": ">=0.59"
+    "react": ">=16.8.6",
+    "react-native": ">=0.60"
   },
   "devDependencies": {
     "@auto-it/all-contributors": "9.28.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@testing-library/react-native": "5.0.3",
     "@types/jest": "25.2.3",
     "@types/react": "16.9.34",
-    "@types/react-native": "0.62.8",
+    "@types/react-native": "0.62.9",
     "all-contributors-cli": "6.15.0",
     "auto": "9.26.8",
     "eslint": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "release-canary": "auto canary"
   },
   "peerDependencies": {
-    "react": ">=16.8.6",
-    "react-native": ">=0.60"
+    "react": ">=16.8.0",
+    "react-native": ">=0.59"
   },
   "devDependencies": {
     "@auto-it/all-contributors": "9.28.3",

--- a/src/useAccessibilityInfo.ts
+++ b/src/useAccessibilityInfo.ts
@@ -12,7 +12,7 @@ type AccessibilityInfoStaticInitializers =
 function useAccessibilityStateListener(
   eventName: AccessibilityChangeEventName,
   initializerName: AccessibilityInfoStaticInitializers,
-): boolean | undefined {
+) {
   const [isEnabled, setIsEnabled] = useState<boolean | undefined>(undefined)
 
   useEffect(() => {
@@ -29,14 +29,7 @@ function useAccessibilityStateListener(
   return isEnabled
 }
 
-export function useAccessibilityInfo(): {
-  screenReaderEnabled: boolean | undefined
-  boldTextEnabled: boolean | undefined
-  grayscaleEnabled: boolean | undefined
-  invertColorsEnabled: boolean | undefined
-  reduceMotionEnabled: boolean | undefined
-  reduceTransparencyEnabled: boolean | undefined
-} {
+export function useAccessibilityInfo() {
   const boldTextEnabled = useAccessibilityStateListener(
     'boldTextChanged',
     'isBoldTextEnabled',

--- a/src/useAccessibilityInfo.ts
+++ b/src/useAccessibilityInfo.ts
@@ -1,13 +1,6 @@
 import {useEffect, useState} from 'react'
 import {AccessibilityInfo, AccessibilityChangeEventName} from 'react-native'
 
-const SUPPORTS_RN60_ACCESSIBILITY_INFO_API = !!(
-  AccessibilityInfo.isGrayscaleEnabled &&
-  AccessibilityInfo.isInvertColorsEnabled &&
-  AccessibilityInfo.isReduceMotionEnabled &&
-  AccessibilityInfo.isReduceTransparencyEnabled
-)
-
 type AccessibilityInfoStaticInitializers =
   | 'isBoldTextEnabled'
   | 'isScreenReaderEnabled'
@@ -16,72 +9,58 @@ type AccessibilityInfoStaticInitializers =
   | 'isReduceMotionEnabled'
   | 'isReduceTransparencyEnabled'
 
-type AccessibilityEventToInfoStaticKeyMap = {
-  [K in AccessibilityChangeEventName]?: AccessibilityInfoStaticInitializers
-}
-
-const EVENT_NAME_TO_INITIALIZER: AccessibilityEventToInfoStaticKeyMap = {
-  boldTextChanged: 'isBoldTextEnabled',
-  screenReaderChanged: 'isScreenReaderEnabled',
-  grayscaleChanged: 'isGrayscaleEnabled',
-  invertColorsChanged: 'isInvertColorsEnabled',
-  reduceMotionChanged: 'isReduceMotionEnabled',
-  reduceTransparencyChanged: 'isReduceTransparencyEnabled',
-}
-
 function useAccessibilityStateListener(
   eventName: AccessibilityChangeEventName,
-): boolean {
-  const [isEnabled, setIsEnabled] = useState(false)
+  initializerName: AccessibilityInfoStaticInitializers,
+): boolean | undefined {
+  const [isEnabled, setIsEnabled] = useState<boolean | undefined>(undefined)
 
   useEffect(() => {
-    const initializerKey = EVENT_NAME_TO_INITIALIZER[eventName]
-
-    if (!initializerKey) {
+    if (!AccessibilityInfo[initializerName]) {
       return
     }
 
-    AccessibilityInfo[initializerKey]().then(setIsEnabled)
+    AccessibilityInfo[initializerName]().then(setIsEnabled)
     AccessibilityInfo.addEventListener(eventName, setIsEnabled)
 
     return () => AccessibilityInfo.removeEventListener(eventName, setIsEnabled)
-  }, [eventName])
+  }, [eventName, initializerName])
 
   return isEnabled
 }
 
 export function useAccessibilityInfo(): {
-  screenReaderEnabled: boolean
-  boldTextEnabled: boolean
-  grayscaleEnabled?: boolean
-  invertColorsEnabled?: boolean
-  reduceMotionEnabled?: boolean
-  reduceTransparencyEnabled?: boolean
+  screenReaderEnabled: boolean | undefined
+  boldTextEnabled: boolean | undefined
+  grayscaleEnabled: boolean | undefined
+  invertColorsEnabled: boolean | undefined
+  reduceMotionEnabled: boolean | undefined
+  reduceTransparencyEnabled: boolean | undefined
 } {
-  const screenReaderEnabled = useAccessibilityStateListener(
-    'screenReaderChanged',
+  const boldTextEnabled = useAccessibilityStateListener(
+    'boldTextChanged',
+    'isBoldTextEnabled',
   )
-  const boldTextEnabled = useAccessibilityStateListener('boldTextChanged')
-
-  if (!SUPPORTS_RN60_ACCESSIBILITY_INFO_API) {
-    return {
-      screenReaderEnabled,
-      boldTextEnabled,
-    }
-  }
-
-  /* eslint-disable react-hooks/rules-of-hooks */
-  const grayscaleEnabled = useAccessibilityStateListener('grayscaleChanged')
+  const grayscaleEnabled = useAccessibilityStateListener(
+    'grayscaleChanged',
+    'isGrayscaleEnabled',
+  )
   const invertColorsEnabled = useAccessibilityStateListener(
     'invertColorsChanged',
+    'isInvertColorsEnabled',
   )
   const reduceMotionEnabled = useAccessibilityStateListener(
     'reduceMotionChanged',
+    'isReduceMotionEnabled',
   )
   const reduceTransparencyEnabled = useAccessibilityStateListener(
     'reduceTransparencyChanged',
+    'isReduceTransparencyEnabled',
   )
-  /* eslint-enable react-hooks/rules-of-hooks */
+  const screenReaderEnabled = useAccessibilityStateListener(
+    'screenReaderChanged',
+    'isScreenReaderEnabled',
+  )
 
   return {
     screenReaderEnabled,

--- a/src/useAccessibilityInfo.ts
+++ b/src/useAccessibilityInfo.ts
@@ -1,13 +1,5 @@
 import {useEffect, useState} from 'react'
-import {AccessibilityInfo, AccessibilityEvent} from 'react-native'
-
-type AccessibilityEventName =
-  | 'boldTextChanged' // iOS-only Event
-  | 'grayscaleChanged' // iOS-only Event
-  | 'invertColorsChanged' // iOS-only Event
-  | 'reduceMotionChanged'
-  | 'screenReaderChanged'
-  | 'reduceTransparencyChanged' // iOS-only Event
+import {AccessibilityInfo, AccessibilityChangeEventName} from 'react-native'
 
 type AccessibilityInfoStaticInitializers =
   | 'isBoldTextEnabled'
@@ -18,7 +10,7 @@ type AccessibilityInfoStaticInitializers =
   | 'isReduceTransparencyEnabled'
 
 type AccessibilityEventToInfoStaticKeyMap = {
-  [K in AccessibilityEventName]?: AccessibilityInfoStaticInitializers
+  [K in AccessibilityChangeEventName]?: AccessibilityInfoStaticInitializers
 }
 
 const EVENT_NAME_TO_INITIALIZER: AccessibilityEventToInfoStaticKeyMap = {
@@ -30,10 +22,8 @@ const EVENT_NAME_TO_INITIALIZER: AccessibilityEventToInfoStaticKeyMap = {
   reduceTransparencyChanged: 'isReduceTransparencyEnabled',
 }
 
-type AccessibilityInfoChangeEventHandler = (event: AccessibilityEvent) => void
-
 function useAccessibilityStateListener(
-  eventName: AccessibilityEventName,
+  eventName: AccessibilityChangeEventName,
 ): boolean {
   const [isEnabled, setIsEnabled] = useState(false)
 
@@ -47,13 +37,13 @@ function useAccessibilityStateListener(
     AccessibilityInfo[initializerKey]().then(setIsEnabled)
     AccessibilityInfo.addEventListener(
       eventName,
-      <AccessibilityInfoChangeEventHandler>setIsEnabled,
+      setIsEnabled,
     )
 
     return () =>
       AccessibilityInfo.removeEventListener(
         eventName,
-        <AccessibilityInfoChangeEventHandler>setIsEnabled,
+        setIsEnabled,
       )
   }, [eventName])
 

--- a/src/useAccessibilityInfo.ts
+++ b/src/useAccessibilityInfo.ts
@@ -51,12 +51,12 @@ function useAccessibilityStateListener(
 }
 
 export function useAccessibilityInfo(): {
-  screenReaderEnabled: Boolean
-  boldTextEnabled: Boolean
-  grayscaleEnabled?: Boolean
-  invertColorsEnabled?: Boolean
-  reduceMotionEnabled?: Boolean
-  reduceTransparencyEnabled?: Boolean
+  screenReaderEnabled: boolean
+  boldTextEnabled: boolean
+  grayscaleEnabled?: boolean
+  invertColorsEnabled?: boolean
+  reduceMotionEnabled?: boolean
+  reduceTransparencyEnabled?: boolean
 } {
   const screenReaderEnabled = useAccessibilityStateListener(
     'screenReaderChanged',

--- a/src/useAccessibilityInfo.ts
+++ b/src/useAccessibilityInfo.ts
@@ -64,7 +64,7 @@ export function useAccessibilityInfo() {
   const screenReaderEnabled = useAccessibilityStateListener(
     'screenReaderChanged',
   )
-  const greyScaleEnabled = useAccessibilityStateListener('grayscaleChanged')
+  const grayscaleEnabled = useAccessibilityStateListener('grayscaleChanged')
   const boldTextEnabled = useAccessibilityStateListener('boldTextChanged')
   const invertColorsEnabled = useAccessibilityStateListener(
     'invertColorsChanged',
@@ -78,7 +78,7 @@ export function useAccessibilityInfo() {
 
   return {
     screenReaderEnabled,
-    greyScaleEnabled,
+    grayscaleEnabled,
     invertColorsEnabled,
     reduceMotionEnabled,
     reduceTransparencyEnabled,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,13 +1614,13 @@
 
 "@types/prop-types@*":
   version "15.7.3"
-  resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-native@0.62.8":
-  version "0.62.8"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.62.8.tgz#224602561f75b838ed6e3b5ea37093bb84cffd74"
-  integrity sha512-YEf0tH3xYJpQB12Vvzoy7cqPY3mvbbulTnG3G7ToKOuJuqigAN3K9NNAaxNAAm1zCj+UtObhzcaJtPRwX1z6Fw==
+"@types/react-native@^0.62.8":
+  version "0.62.9"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.62.9.tgz#f75d4a8879e68ed3857d6f2f73dc0752a0505362"
+  integrity sha512-OcoE7SKz1PsvTGJK5fIwJu6kWdDFN+hH1vMI4GVTEBYhV5FAM5vKVUFCaSiEPJScyNyIEWAeQwFvI3a01+Grzg==
   dependencies:
     "@types/react" "*"
 
@@ -1632,9 +1632,9 @@
     "@types/react" "*"
 
 "@types/react@*":
-  version "16.9.25"
-  resolved "https://registry.npmjs.org/@types/react/-/react-16.9.25.tgz#6ae2159b40138c792058a23c3c04fd3db49e929e"
-  integrity sha512-Dlj2V72cfYLPNscIG3/SMUOzhzj7GK3bpSrfefwt2YT9GLynvLCCZjbhyF6VsT0q0+aRACRX03TDJGb7cA0cqg==
+  version "16.9.35"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.35.tgz#a0830d172e8aadd9bd41709ba2281a3124bbd368"
+  integrity sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -2823,9 +2823,9 @@ cssstyle@^2.2.0:
     cssom "~0.3.6"
 
 csstype@^2.2.0:
-  version "2.6.9"
-  resolved "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
-  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
+  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
 dashdash@^1.12.0:
   version "1.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,7 +1617,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-native@^0.62.8":
+"@types/react-native@0.62.9":
   version "0.62.9"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.62.9.tgz#f75d4a8879e68ed3857d6f2f73dc0752a0505362"
   integrity sha512-OcoE7SKz1PsvTGJK5fIwJu6kWdDFN+hH1vMI4GVTEBYhV5FAM5vKVUFCaSiEPJScyNyIEWAeQwFvI3a01+Grzg==


### PR DESCRIPTION
# Summary

I added several other [Accessibility features](https://reactnative.dev/docs/accessibilityinfo) to the`useAccessibilityInfo` hook.

Note: ~~this does break backwards compatibility with 0.59 which only implements two of the listed accessibility features~~

## Test Plan

Tested the branch in our RN App

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ❌     |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I've created a snack to demonstrate the changes

Unclear how to make a snack that points to a forked branch. Would love advice on this if expo snack supports it
