### PR TITLE
Change useDeviceOrientation design

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,7 @@ import { useDeviceOrientation } from '@react-native-community/hooks'
 
 const orientation = useDeviceOrientation()
 
-console.log('is orientation portrait: ', orientation.portrait)
-console.log('is orientation landscape: ', orientation.landscape)
+console.log('orientation is: ', orientation)
 ```
 
 ### `useLayout`

--- a/src/useDeviceOrientation.ts
+++ b/src/useDeviceOrientation.ts
@@ -4,31 +4,18 @@ import {Dimensions, ScaledSize} from 'react-native'
 const screen = Dimensions.get('screen')
 
 export function useDeviceOrientation() {
-  const isOrientationPortrait = ({
+  const getOrientation = ({
     width,
     height,
   }: {
     width: number
     height: number
-  }) => height >= width
-  const isOrientationLandscape = ({
-    width,
-    height,
-  }: {
-    width: number
-    height: number
-  }) => width >= height
+  }) => height >= width ? 'portrait' : 'landscape'
 
-  const [orientation, setOrientation] = useState({
-    portrait: isOrientationPortrait(screen),
-    landscape: isOrientationLandscape(screen),
-  })
+  const [orientation, setOrientation] = useState(getOrientation(screen))
 
   const onChange = useCallback(({screen: scr}: {screen: ScaledSize}) => {
-    setOrientation({
-      portrait: isOrientationPortrait(scr),
-      landscape: isOrientationLandscape(scr),
-    })
+    setOrientation(getOrientation(scr))
   }, [])
 
   useEffect(() => {
@@ -37,7 +24,7 @@ export function useDeviceOrientation() {
     return () => {
       Dimensions.removeEventListener('change', onChange)
     }
-  }, [orientation.portrait, orientation.landscape, onChange])
+  }, [onChange])
 
   return orientation
 }


### PR DESCRIPTION
Returns `'portrait' | 'landscape'` instead of object with two booleans.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

I found the `useDeviceOrientation` hook's design pretty weird. Returning an object with two booleans can be simplified to return a simple type: `'landscape' | 'portrait'`. This is only a proposal with a simple solution, if requested I will also write tests.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
| Web     |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
