### PR TITLE
prevent setting state for unmounted component in useImageDimensions hook

### DIFF
--- a/src/useImageDimensions.ts
+++ b/src/useImageDimensions.ts
@@ -29,14 +29,17 @@ export function useImageDimensions(
   const [result, setResult] = useState<ImageDimensionsResult>({loading: true})
 
   useEffect(() => {
+    let mounted = true
     try {
       if (typeof source === 'number') {
         const {width, height} = Image.resolveAssetSource(source)
 
-        setResult({
-          dimensions: {width, height, aspectRatio: width / height},
-          loading: false,
-        })
+        if (mounted) {
+          setResult({
+            dimensions: {width, height, aspectRatio: width / height},
+            loading: false,
+          })
+        }
 
         return
       }
@@ -46,12 +49,19 @@ export function useImageDimensions(
 
         Image.getSize(
           source.uri,
-          (width, height) =>
-            setResult({
-              dimensions: {width, height, aspectRatio: width / height},
-              loading: false,
-            }),
-          (error) => setResult({error, loading: false}),
+          (width: number, height: number) => {
+            if (mounted) {
+              setResult({
+                dimensions: {width, height, aspectRatio: width / height},
+                loading: false,
+              })
+            }
+          },
+          (error: Error) => {
+            if (mounted) {
+              setResult({error, loading: false})
+            }
+          },
         )
 
         return
@@ -61,6 +71,7 @@ export function useImageDimensions(
     } catch (error) {
       setResult({error, loading: false})
     }
+    return () => (mounted = false)
   }, [source])
 
   return result


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
useImageDimension hook use async function Image.getSize which accept a callback,  setState is called asynchronously which  will lead to a warning when the component that uses the hook is unmounted.
 
Warning: Can't call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method,
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
| Web     |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
- [] I've created a snack to demonstrate the changes: LINK HERE
