### PR TITLE
feat: add useKeyboardRelease hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ console.log('layout: ', layout)
 ### `useKeyboardRelease`
 
 ```js
-import { useKeyboardRelease } from '@react-native-community/hooks'
+import {useKeyboardRelease} from '@react-native-community/hooks'
 
-const { onRelease, shouldSetResponse } = useKeyboardRelease()
+const {onRelease, shouldSetResponse} = useKeyboardRelease()
 
-<View onResponderRelease={ onRelease } onStartShouldSetResponder={ shouldSetResponse }>
+<View onResponderRelease={onRelease} onStartShouldSetResponder={shouldSetResponse}>
 ```
 
 [version-badge]: https://img.shields.io/npm/v/@react-native-community/hooks.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ console.log('layout: ', layout)
 <View onLayout={onLayout} style={{width: 200, height: 200, marginTop: 30}} />
 ```
 
+### `useKeyboardRelease`
+
+```js
+import { useKeyboardRelease } from '@react-native-community/hooks'
+
+const { onRelease, shouldSetResponse } = useKeyboardRelease()
+
+<View onResponderRelease={ onRelease } onStartShouldSetResponder={ shouldSetResponse }>
+```
+
 [version-badge]: https://img.shields.io/npm/v/@react-native-community/hooks.svg?style=flat-square
 [package]: https://www.npmjs.com/package/@react-native-community/hooks
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {useInteractionManager} from './useInteractionManager'
 import {useDeviceOrientation} from './useDeviceOrientation'
 import {useLayout} from './useLayout'
 import {useImageDimensions} from './useImageDimensions'
+import {useKeyboardRelease} from './useKeyboardRelease'
 
 export {
   useDimensions,
@@ -23,4 +24,5 @@ export {
   useDeviceOrientation,
   useLayout,
   useImageDimensions,
+  useKeyboardRelease,
 }

--- a/src/useKeyboardRelease.ts
+++ b/src/useKeyboardRelease.ts
@@ -1,4 +1,4 @@
-import {Keyboard} from 'react-native'
+import {Keyboard, Platform} from 'react-native'
 
 export interface KeyboardReleaseReturns {
   shouldSetResponse: () => boolean
@@ -6,7 +6,7 @@ export interface KeyboardReleaseReturns {
 }
 
 export function useKeyboardRelease(): KeyboardReleaseReturns {
-  const shouldSetResponse = () => true
+  const shouldSetResponse = () => (Platform.OS === 'web' ? false : true)
   const onRelease = () => Keyboard.dismiss()
 
   return {onRelease, shouldSetResponse}

--- a/src/useKeyboardRelease.ts
+++ b/src/useKeyboardRelease.ts
@@ -1,4 +1,4 @@
-import { Keyboard } from 'react-native'
+import {Keyboard} from 'react-native'
 
 export interface KeyboardReleaseReturns {
   shouldSetResponse: () => boolean
@@ -9,5 +9,5 @@ export function useKeyboardRelease(): KeyboardReleaseReturns {
   const shouldSetResponse = () => true
   const onRelease = () => Keyboard.dismiss()
 
-  return { onRelease, shouldSetResponse }
+  return {onRelease, shouldSetResponse}
 }

--- a/src/useKeyboardRelease.ts
+++ b/src/useKeyboardRelease.ts
@@ -1,0 +1,13 @@
+import { Keyboard } from 'react-native'
+
+export interface KeyboardReleaseReturns {
+  shouldSetResponse: () => boolean
+  onRelease: () => void
+}
+
+export function useKeyboardRelease(): KeyboardReleaseReturns {
+  const shouldSetResponse = () => true
+  const onRelease = () => Keyboard.dismiss()
+
+  return { onRelease, shouldSetResponse }
+}


### PR DESCRIPTION
# Summary

Allows user to easily dismiss the keyboard inside React Native views.

Info: https://justinnoel.dev/2020/11/17/react-native-dismiss-keyboard-custom-hook/


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

Unknown

### What are the steps to reproduce (after prerequisites)?

Unknown


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X ] I have tested this on a device and a simulator
- [X ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [X ] I've created a snack to demonstrate the changes: https://snack.expo.io/@calendee/usekeyboardrelease-demo
