### PR TITLE
Add the option to pass headers to useImageDimensions

### DIFF
--- a/src/useImageDimensions.ts
+++ b/src/useImageDimensions.ts
@@ -1,5 +1,5 @@
 import {useEffect, useState} from 'react'
-import {Image, ImageRequireSource} from 'react-native'
+import {Image, ImageRequireSource, ImageURISource} from 'react-native'
 
 export interface URISource {
   uri: string
@@ -21,10 +21,12 @@ export interface ImageDimensionsResult {
 
 /**
  * @param source either a remote URL or a local file resource.
+ * @param headers headers to be passed to a remote URL resource.
  * @returns original image dimensions (width, height and aspect ratio).
  */
 export function useImageDimensions(
   source: ImageDimensionsSource,
+  headers?: ImageURISource['headers']
 ): ImageDimensionsResult {
   const [result, setResult] = useState<ImageDimensionsResult>({loading: true})
 
@@ -43,16 +45,29 @@ export function useImageDimensions(
 
       if (typeof source === 'object' && source.uri) {
         setResult({loading: true})
-
-        Image.getSize(
-          source.uri,
-          (width, height) =>
-            setResult({
-              dimensions: {width, height, aspectRatio: width / height},
-              loading: false,
-            }),
-          (error) => setResult({error, loading: false}),
-        )
+        
+        if (typeof headers === 'object') {
+          Image.getSizeWithHeaders(
+            source.uri,
+            headers,
+            (width, height) =>
+              setResult({
+                dimensions: {width, height, aspectRatio: width / height},
+                loading: false,
+              }),
+            (error) => setResult({error, loading: false}),
+          )
+        } else {
+          Image.getSize(
+            source.uri,
+            (width, height) =>
+              setResult({
+                dimensions: {width, height, aspectRatio: width / height},
+                loading: false,
+              }),
+            (error) => setResult({error, loading: false}),
+          )
+        }
 
         return
       }


### PR DESCRIPTION
# Summary

When using headers (for example for authentication) together with `Image`, you could not use `useImageDimensions` because it only included `Image.getSize` to determine the size of a remote image. This PR adds support for passing a second optional `headers` param to `useImageDimensions` which will then use `Image.getSizeWithHeaders` from React Native.

## Test Plan

```tsx
const ImageViewer = ({ uri, headers }) => {
  const { width, height } = useImageDimensions(uri, headers)
  return <Image style={{ width, height }} />
}

<ImageViewer uri="https://...." headers={{ authorization: `Bearer  ....` }} />
```

### What's required for testing (prerequisites)?

A remote resource which requires a header (e.g auth header)

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've created a snack to demonstrate the changes: LINK HERE

## Notes

I edited this PR via Github, let me know if it requires changes
