### PR TITLE
Cancel InteractionManager's task on unmount

### DIFF
--- a/src/useInteractionManager.ts
+++ b/src/useInteractionManager.ts
@@ -5,9 +5,14 @@ export function useInteractionManager() {
   const [complete, updateInteractionStatus] = useState(false)
 
   useEffect(() => {
-    InteractionManager.runAfterInteractions(() => {
+    const {cancel} = InteractionManager.runAfterInteractions(() => {
       updateInteractionStatus(true)
     })
+
+    return () => {
+      cancel?.()
+    }
   }, [])
+
   return complete
 }


### PR DESCRIPTION
There are some cases when interaction manager's task executing when component have already unmounted and React return a warning when setState happed on unmounted component. The whole warning you can see below: 

`Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function`

So this tiny fix will cancel task on component unmount. 
