### PR TITLE
fix: useAppState replace deprecated removeEventListener with subscrip…

### DIFF
--- a/src/useAppState.ts
+++ b/src/useAppState.ts
@@ -10,10 +10,10 @@ export function useAppState() {
   }
 
   useEffect(() => {
-    AppState.addEventListener('change', onChange)
+    const subscription = AppState.addEventListener('change', onChange)
 
     return () => {
-      AppState.removeEventListener('change', onChange)
+      subscription.remove();
     }
   }, [])
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
The `removeEventListener` method was deprecated, replaced by the `remove` method on the event subscription returned by `addEventListener()`.
Refer to [RN docs](https://reactnative.dev/docs/appstate#removeeventlistener) .
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅     |
| Web     |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
