### PR TITLE
Add useKeyboard() hook tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,15 @@
 module.exports = {
-  preset: 'ts-jest',
+  testEnvironment: 'node',
+  preset: 'react-native',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+    },
+  },
+  transform: {
+    '^.+\\.jsx$': 'babel-jest',
+    '^.+\\.tsx?$': 'ts-jest',
+  },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testPathIgnorePatterns: ['node_modules', 'lib'],
 }

--- a/src/useKeyboard.test.ts
+++ b/src/useKeyboard.test.ts
@@ -1,0 +1,99 @@
+import {useKeyboard} from './useKeyboard'
+import {act, renderHook} from '@testing-library/react-hooks'
+import {Keyboard} from 'react-native'
+
+describe('useKeyboard', () => {
+  const mockCoords = {screenX: 0, screenY: 0, width: 0, height: 0}
+  const emitKeyboardEvent = ({
+    show = true,
+    startCoordinates = mockCoords,
+    endCoordinates = mockCoords,
+  }) => {
+    const mockEvent = {startCoordinates, endCoordinates}
+
+    Keyboard.emit(
+      show ? 'keyboardDidShow' : 'keyboardDidHide',
+      show ? mockEvent : null,
+    )
+  }
+
+  describe('setKeyboardHeight: number', () => {
+    it('keyboard height is zero by default', () => {
+      const {result} = renderHook(() => useKeyboard())
+
+      expect(result.current.keyboardHeight).toBe(0)
+    })
+
+    it('should update keyboard height when keyboard will open', () => {
+      const height = 123
+      const {result} = renderHook(() => useKeyboard())
+
+      act(() => {
+        emitKeyboardEvent({show: true, endCoordinates: {...mockCoords, height}})
+      })
+
+      expect(result.current.keyboardHeight).toBe(height)
+    })
+
+    it('should reset keyboard height when keyboard will close', () => {
+      const height = 123
+      const {result} = renderHook(() => useKeyboard())
+
+      act(() => {
+        emitKeyboardEvent({show: true, endCoordinates: {...mockCoords, height}})
+      })
+
+      expect(result.current.keyboardHeight).toBe(height)
+
+      act(() => {
+        emitKeyboardEvent({show: false})
+      })
+
+      expect(result.current.keyboardHeight).toBe(0)
+    })
+  })
+
+  describe('keyboardShown: boolean', () => {
+    it('keyboard closed by default', () => {
+      const {result} = renderHook(() => useKeyboard())
+
+      expect(result.current.keyboardShown).toBe(false)
+    })
+
+    it('should set keyboardShown when keyboard will open', () => {
+      const {result} = renderHook(() => useKeyboard())
+      const {keyboardShown: initial} = result.current
+
+      act(() => {
+        emitKeyboardEvent({show: true})
+      })
+
+      const {keyboardShown: afterOpen} = result.current
+
+      expect({initial, afterOpen}).toEqual({initial: false, afterOpen: true})
+    })
+
+    it('should reset keyboardShown when keyboard will close', () => {
+      const {result} = renderHook(() => useKeyboard())
+      const {keyboardShown: initial} = result.current
+
+      act(() => {
+        emitKeyboardEvent({show: true})
+      })
+
+      const {keyboardShown: afterOpen} = result.current
+
+      act(() => {
+        emitKeyboardEvent({show: false})
+      })
+
+      const {keyboardShown: afterClose} = result.current
+
+      expect({initial, afterOpen, afterClose}).toEqual({
+        initial: false,
+        afterOpen: true,
+        afterClose: false,
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Summary

Added test for `useKeyboard()` hook

Also to fix transform issues (`ts-jest` cannot import react-native, because it is flow.js syntax). So, using [an official guide](https://kulshekhar.github.io/ts-jest/docs/guides/react-native/) I update jest configuration

## Test Plan

`yarn test`

### What's required for testing (prerequisites)?

...

### What are the steps to reproduce (after prerequisites)?

...

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist


- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
