### PR TITLE
Add useAppState tests

### DIFF
--- a/src/useAppState.test.ts
+++ b/src/useAppState.test.ts
@@ -1,0 +1,50 @@
+import {act, renderHook} from '@testing-library/react-hooks'
+import {AppState, AppStateStatus} from 'react-native'
+import {useAppState} from './useAppState'
+
+jest.mock('react-native', () => ({
+  AppState: {
+    currentState: 'mock-currentState',
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  },
+}))
+
+describe('useAppState', () => {
+  const addEventListenerMock = AppState.addEventListener as jest.Mock
+  const createEmitAppStateChange = () => {
+    let listener: (newStatus: AppStateStatus) => {}
+
+    addEventListenerMock.mockImplementationOnce((_, fn) => {
+      listener = fn
+    })
+
+    return (newStatus: AppStateStatus) => listener(newStatus)
+  }
+
+  it('should return current state by default', () => {
+    const {result} = renderHook(() => useAppState())
+
+    expect(result.current).toBe(AppState.currentState)
+  })
+
+  it('should update state when it change', () => {
+    const newStatus = 'background'
+    const emit = createEmitAppStateChange()
+
+    const {result} = renderHook(() => useAppState())
+
+    const {current: initialStatus} = result
+
+    act(() => {
+      emit(newStatus)
+    })
+
+    const {current: statusAfterUpdate} = result
+
+    expect({initialStatus, statusAfterUpdate}).toEqual({
+      initialStatus: AppState.currentState,
+      statusAfterUpdate: newStatus,
+    })
+  })
+})

--- a/src/useAppState.ts
+++ b/src/useAppState.ts
@@ -5,11 +5,11 @@ export function useAppState() {
   const currentState = AppState.currentState
   const [appState, setAppState] = useState(currentState)
 
-  function onChange(newState: AppStateStatus) {
-    setAppState(newState)
-  }
-
   useEffect(() => {
+    function onChange(newState: AppStateStatus) {
+      setAppState(newState)
+    }
+
     AppState.addEventListener('change', onChange)
 
     return () => {


### PR DESCRIPTION
# Summary

- Add `useAppState(...)` tests
- Move `onChange` callback inside `useEffect` hook  (not need to create this function on each render, memory usage improvements)


## Test Plan

```bash
yarn test
```

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
