### PR TITLE
Prevent "maximum update depth exceeded" error when pass image as a new object on each render

### DIFF
--- a/src/useImageDimensions.ts
+++ b/src/useImageDimensions.ts
@@ -76,7 +76,8 @@ export function useImageDimensions(
     } catch (error) {
       setResult({error, loading: false})
     }
-  }, [source, headers])
+    // eslint-disable-next-line
+  }, [typeof source === 'object' ? source.uri : source, headers])
 
   return result
 }


### PR DESCRIPTION
# Summary

Don't use source as `useEffect` dependency when it objects, to fix next issue:

```
useImageDimensions({uri: '...'})
                   ^^^
                   ERROR: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect,
                                   but useEffect either doesn't have a dependency array, 
                                   or one of the dependencies changes on every render.
```


## Test Plan

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

See expo snack below...

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [x] I've created a snack to demonstrate the changes: https://snack.expo.dev/@retyui/react-native-community_hooks_issue
