### PR TITLE
[Fix][useKeyboard] Adapt unsubscription for new EventEmitter API

### DIFF
--- a/src/useKeyboard.ts
+++ b/src/useKeyboard.ts
@@ -50,18 +50,7 @@ export function useKeyboard() {
     ]
 
     return () => {
-      if (Keyboard.removeListener) {
-        // React Native < 0.65
-        Keyboard.removeListener('keyboardWillShow', handleKeyboardWillShow)
-        Keyboard.removeListener('keyboardDidShow', handleKeyboardDidShow)
-        Keyboard.removeListener('keyboardWillHide', handleKeyboardWillHide)
-        Keyboard.removeListener('keyboardDidHide', handleKeyboardDidHide)
-      } else {
-        // React Native >= 0.65
-        for (const subscription of subscriptions) {
-          subscription.remove()
-        }
-      }
+      subscriptions.forEach((subscription) => subscription.remove())
     }
   }, [])
   return {


### PR DESCRIPTION
# Summary

Issue: https://github.com/react-native-community/hooks/pull/268#issuecomment-966604027

```jsx
// React Native 0.65.x +
typeof Keyboard.removeListener // function
Keyboard.removeListener(...) // print warning
```

## Test Plan


### What's required for testing (prerequisites)?

- React Native >= `0.65`

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
