### PR TITLE
Deprecate hooks that use old API (fix: #267)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ yarn add @react-native-community/hooks
 - [useAccessibilityInfo](https://github.com/react-native-community/hooks#useaccessibilityinfo)
 - [useAppState](https://github.com/react-native-community/hooks#useappstate)
 - [useBackHandler](https://github.com/react-native-community/hooks#usebackhandler)
-- [useCameraRoll](https://github.com/react-native-community/hooks#usecameraroll)
-- [useClipboard](https://github.com/react-native-community/hooks#useclipboard)
+- ~~[useCameraRoll](https://github.com/react-native-community/hooks#usecameraroll)~~
+- ~~[useClipboard](https://github.com/react-native-community/hooks#useclipboard)~~
 - [useDimensions](https://github.com/react-native-community/hooks#usedimensions)
 - [useImageDimensions](https://github.com/react-native-community/hooks#useImageDimensions)
 - [useKeyboard](https://github.com/react-native-community/hooks#usekeyboard)
@@ -74,6 +74,8 @@ useBackHandler(() => {
 
 ### `useCameraRoll`
 
+⚠️ **Deprecated**. Please use `useCameraRoll()` from [`@react-native-camera-roll/camera-roll`](https://github.com/react-native-cameraroll/react-native-cameraroll#usecameraroll) 
+
 ```js
 import { useCameraRoll } from '@react-native-community/hooks'
 
@@ -87,6 +89,8 @@ const [photos, getPhotos, saveToCameraRoll] = useCameraRoll()
 ```
 
 ### `useClipboard`
+
+⚠️ **Deprecated**. Please use `useClipboard()` from [`@react-native-clipboard/clipboard`](https://github.com/react-native-clipboard/clipboard#useclipboard)
 
 ```js
 import { useClipboard } from '@react-native-community/hooks'

--- a/src/useCameraRoll.ts
+++ b/src/useCameraRoll.ts
@@ -15,6 +15,10 @@ const defaultConfig: GetPhotosParamType = {
   groupTypes: 'All',
 }
 
+/**
+ * @deprecated Please use "useCameraRoll" from "@react-native-camera-roll/camera-roll" instead
+ * More: https://github.com/react-native-cameraroll/react-native-cameraroll#usecameraroll
+ */
 export function useCameraRoll() {
   const [photos, setPhotos] = useState(initialState)
 

--- a/src/useClipboard.ts
+++ b/src/useClipboard.ts
@@ -9,6 +9,10 @@ function setString(content: string) {
   listeners.forEach((listener) => listener(content))
 }
 
+/**
+ * @deprecated Please use "useClipboard" from "@react-native-clipboard/clipboard" instead
+ * More: https://github.com/react-native-clipboard/clipboard#useclipboard
+ */
 export function useClipboard(): [string, (content: string) => void] {
   const [data, updateClipboardData] = useState('')
 


### PR DESCRIPTION
# Summary

Issue: https://github.com/react-native-community/hooks/issues/267
Preview [`README.md`](https://github.com/react-native-community/hooks/blob/2d3b76973eeee780d0fcca63d84f055c93db163f/README.md)


## Test Plan

![image](https://user-images.githubusercontent.com/4661784/201988150-825a4cd0-fbd8-4808-809a-7ad0aed9edfa.png)


### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
