### PR TITLE
chore: [useKeyboard] Reduce re-renders amount

### DIFF
--- a/src/useKeyboard.ts
+++ b/src/useKeyboard.ts
@@ -1,44 +1,52 @@
 import {useEffect, useState} from 'react'
 import {Keyboard, KeyboardEventListener, KeyboardMetrics} from 'react-native'
 
-const emptyCoordinates = Object.freeze({
+const emptyCoordinates: KeyboardMetrics = Object.freeze({
   screenX: 0,
   screenY: 0,
   width: 0,
   height: 0,
 })
 const initialValue = {
-  start: emptyCoordinates,
+  start: emptyCoordinates as KeyboardMetrics | undefined,
   end: emptyCoordinates,
+}
+const defaultState = {
+  keyboardShown: false,
+  coordinates: initialValue,
+  keyboardHeight: 0,
 }
 
 export function useKeyboard() {
-  const [shown, setShown] = useState(false)
-  const [coordinates, setCoordinates] = useState<{
-    start: undefined | KeyboardMetrics
-    end: KeyboardMetrics
-  }>(initialValue)
-  const [keyboardHeight, setKeyboardHeight] = useState<number>(0)
+  const [state, setState] = useState(defaultState)
 
   const handleKeyboardWillShow: KeyboardEventListener = (e) => {
-    setCoordinates({start: e.startCoordinates, end: e.endCoordinates})
+    setState((prevState) => ({
+      ...prevState,
+      coordinates: {start: e.startCoordinates, end: e.endCoordinates},
+    }))
   }
   const handleKeyboardDidShow: KeyboardEventListener = (e) => {
-    setShown(true)
-    setCoordinates({start: e.startCoordinates, end: e.endCoordinates})
-    setKeyboardHeight(e.endCoordinates.height)
+    setState(() => ({
+      keyboardShown: true,
+      coordinates: {start: e.startCoordinates, end: e.endCoordinates},
+      keyboardHeight: e.endCoordinates.height,
+    }))
   }
   const handleKeyboardWillHide: KeyboardEventListener = (e) => {
-    setCoordinates({start: e.startCoordinates, end: e.endCoordinates})
+    setState((prevState) => ({
+      ...prevState,
+      coordinates: {start: e.startCoordinates, end: e.endCoordinates},
+    }))
   }
   const handleKeyboardDidHide: KeyboardEventListener = (e) => {
-    setShown(false)
-    if (e) {
-      setCoordinates({start: e.startCoordinates, end: e.endCoordinates})
-    } else {
-      setCoordinates(initialValue)
-      setKeyboardHeight(0)
-    }
+    setState((prevState) => ({
+      keyboardShown: false,
+      coordinates: e
+        ? {start: e.startCoordinates, end: e.endCoordinates}
+        : initialValue,
+      keyboardHeight: e ? prevState.keyboardHeight : 0,
+    }))
   }
 
   useEffect(() => {
@@ -54,9 +62,5 @@ export function useKeyboard() {
     }
   }, [])
 
-  return {
-    keyboardShown: shown,
-    coordinates,
-    keyboardHeight,
-  }
+  return state
 }


### PR DESCRIPTION
# Summary

I see that my component is re-render 3 times on `keyboardDidShow` event as `useKeyboard` has 3 setState invokes 
Using a single state should solve this problem on all old and modern ver. or react 

## Test Plan

...

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
