### PR TITLE
Use EventSubscription to unsubscribe from BackHandler

### DIFF
--- a/src/useBackHandler.test.ts
+++ b/src/useBackHandler.test.ts
@@ -2,16 +2,20 @@ import {useBackHandler} from './useBackHandler'
 import {renderHook} from '@testing-library/react-hooks'
 import {BackHandler} from 'react-native'
 
+const removeEventListenerMock = jest.fn()
+
 jest.mock('react-native', () => ({
   BackHandler: {
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
+    addEventListener: jest.fn().mockImplementation(() => {
+      return {
+        remove: removeEventListenerMock,
+      }
+    }),
   },
 }))
 
 describe('useBackHandler', () => {
   const addEventListenerMock = BackHandler.addEventListener as jest.Mock
-  const removeEventListenerMock = BackHandler.removeEventListener as jest.Mock
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -40,7 +44,7 @@ describe('useBackHandler', () => {
 
     rerender({handler: handler2})
 
-    expect(removeEventListenerMock).toBeCalledWith('hardwareBackPress', handler)
+    expect(removeEventListenerMock).toBeCalledTimes(1)
     expect(addEventListenerMock).toBeCalledWith('hardwareBackPress', handler2)
   })
 
@@ -56,6 +60,5 @@ describe('useBackHandler', () => {
     unmount()
 
     expect(removeEventListenerMock).toBeCalledTimes(1)
-    expect(removeEventListenerMock).toBeCalledWith('hardwareBackPress', handler)
   })
 })

--- a/src/useBackHandler.ts
+++ b/src/useBackHandler.ts
@@ -3,8 +3,8 @@ import {BackHandler} from 'react-native'
 
 export function useBackHandler(handler: () => boolean) {
   useEffect(() => {
-    BackHandler.addEventListener('hardwareBackPress', handler)
+    const subscription = BackHandler.addEventListener('hardwareBackPress', handler)
 
-    return () => BackHandler.removeEventListener('hardwareBackPress', handler)
+    return () => subscription.remove()
   }, [handler])
 }


### PR DESCRIPTION
# Summary

RN 0.77.0 contains a PR removing `removeEventListener` from `BackHandler` (https://github.com/facebook/react-native/pull/45892)

This PR uses suggested migration of using `remove` on `EventSubscription`
